### PR TITLE
Being more strict about what executable to run

### DIFF
--- a/card_reader.sh
+++ b/card_reader.sh
@@ -5,7 +5,7 @@ function call_open_door {
     if [ $1 = "1" ]
     then
         echo "Access Granted!"
-        python ./open_door.py
+        python $(dirname $0)/open_door.py
     fi
 }
 


### PR DESCRIPTION
In the case where the `card_reader.sh` script it called from outside of the project directory, the original `./` will call any scripted named `open_door.py` in the current directory. This is not necessary the same Python script as what was shipped with the project. This fix ensures the `open_door.py` script from the project directory is run at all times.